### PR TITLE
Fixed spelling and grammer errors in ToolView.xaml

### DIFF
--- a/EventMapHpViewer/ToolView.xaml
+++ b/EventMapHpViewer/ToolView.xaml
@@ -155,7 +155,7 @@
                                     <Run Text=""/>
                                     <Run Text="{Binding RemainingCount}"
                                          Style="{DynamicResource EmphaticTextElementStyleKey}"/>
-                                    <Run Text="kills remains"/>
+                                    <Run Text="kills remain"/>
                                 </TextBlock>
                                 
                                 <TextBlock Grid.Column="3"
@@ -176,7 +176,7 @@
                                       Visibility="{Binding IsRankSelected, Converter={StaticResource FalseToVisibleConverter}}">
                                     <Border Background="{DynamicResource ThemeBrushKey}"
                                             Margin="0" />
-                                    <TextBlock Text="Please chose difficult"
+                                    <TextBlock Text="Please choose difficulty"
                                                VerticalAlignment="Center"
                                                HorizontalAlignment="Center" />
                                 </Grid>
@@ -191,9 +191,9 @@
                    TextWrapping="WrapWithOverflow"
                    Margin="5,15">
             ※Go to sortie selection section to refresh<LineBreak/>
-            ※Event map's HP decreases by the amount of damage that the flagship of boss node had taken.<LineBreak/>
+            ※Event map's HP decreases by the amount of damage that the flagship of boss node has taken.<LineBreak/>
             <LineBreak/>
-            ■Support event: Summer 2014 ～ Spring 2015<LineBreak/>
+            ■Supported events: Summer 2014 ～ Spring 2015<LineBreak/>
         </TextBlock>
     </Grid>
 </UserControl>


### PR DESCRIPTION
First at line 158 I changed kills remains to kills remain since you should not have an s on a verb that modifies a plural noun (kills here). At 179 I modified it assuming that it was referring to the difficulty selector that has been in the last two events therefore changing "Please chose difficult" to "Please choose difficulty" would make scene since choose is the present form of the verb (chose is the past or could have been a typo) and difficulty referrers to condition of the difficult, that is to say how hard it is rather than just difficult which implies that it is hard. On 194 I changed had to had because it seemed that the sentence was more likely meaning to be a present perfect tense (talking about an event that started in the past but is still happening in the present) though this change is one that could be debated based on how you want to write it. Finally, on 196 I changed "Support event" to "Supported events" because this would be another case of the present perfect tense (started in the past and continuing into the future) so the verb should be past tense and since there is more than one event supported event is made plural.
